### PR TITLE
Fix the mod ID of YACL

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -38,6 +38,6 @@
 	},
 	"recommends": {
 		"modmenu": ">=7.0.0",
-		"yacl": ">=3.2.2"
+		"yet_another_config_lib_v3": ">=3.2.2"
 	}
 }


### PR DESCRIPTION
Currently, the mod ID of YACL written in the 'recommends' section is `yacl`. However, YACL use the ID `yet_another_config_lib_v3` instead. This will prevent the waring in log still popping up when you install YACL aready.
~i know its unnecessary but so~